### PR TITLE
Fix: removed unused JWT output type from usage help text.

### DIFF
--- a/cvm-attestation-sample-app/main.cpp
+++ b/cvm-attestation-sample-app/main.cpp
@@ -13,8 +13,8 @@
 using json = nlohmann::json;
 
 
-#define OUTPUT_TYPE_JWT "TOKEN"
-#define OUTPUT_TYPE_BOOL "BOOL"
+#define OUTPUT_TYPE_JWT "token"
+#define OUTPUT_TYPE_BOOL "bool"
 
 // default guest attestation url
 std::string default_attestation_url = "https://sharedeus2.eus2.attest.azure.net/";
@@ -58,7 +58,7 @@ static int getopt(int argc, char* const argv[], const char* optstring)
 #endif //!PLATFORM_UNIX
 
 void usage(char* programName) {
-    printf("Usage: %s -a <attestation-endpoint> -n <nonce> -o JWT\n", programName);
+    printf("Usage: %s -a <attestation-endpoint> -n <nonce> -o <%s|%s>\n", programName, OUTPUT_TYPE_BOOL, OUTPUT_TYPE_JWT);
 }
 
 int main(int argc, char* argv[]) {


### PR DESCRIPTION
Fix: removed unused JWT output type from usage help text.

Upon using `-o JWT` as suggested in the repo's documentation, this would cause the output to be `true` or `false`. This is due to the input for `output_type` being set to `"JWT"`, after which it is compared to value `"TOKEN"`.

https://github.com/Azure/confidential-computing-cvm-guest-attestation/blob/1935d51c4950e304756c9346ee28ce13f3d3f7f4/cvm-attestation-sample-app/main.cpp#L154-L159

I changed the macro value and the way it is presented in the usage help text.
