### PR TITLE
Fixing SevSnpReport

### DIFF
--- a/client-library/src/external/SnpVmReport/SnpVmReport.h
+++ b/client-library/src/external/SnpVmReport/SnpVmReport.h
@@ -121,6 +121,7 @@ typedef struct _HW_ATTESTATION
 typedef enum _IGVM_REPORT_TYPE
 {
     InvalidReport = 0,
+    ReservedReportType,
     SnpVmReport,
     TvmReport
 } IGVM_REPORT_TYPE, *PIGVM_REPORT_TYPE;


### PR DESCRIPTION
Adding reserved spot in IGVM report type enum
