### PR TITLE
Fixes for Attestation URL, Nonce and Client Id for IMDS auth 

### DIFF
--- a/cvm-securekey-release-app/AttestationUtil.cpp
+++ b/cvm-securekey-release-app/AttestationUtil.cpp
@@ -250,7 +250,7 @@ std::string Util::GetMAAToken(const std::string &attestation_url, const std::str
     // parameters for the Attest call
     attest::ClientParameters params = {};
     params.attestation_endpoint_url = (PBYTE)attest_server_url.c_str();
-    std::string client_payload_str = "{\"nonce\": \"" + nonce + "\"}"; // nonce is optional
+    std::string client_payload_str = "{\"nonce\": \"" + nonce_token + "\"}"; // nonce is optional
     params.client_payload = (PBYTE)client_payload_str.c_str();
     params.version = CLIENT_PARAMS_VERSION;
     PBYTE jwt = nullptr;

--- a/cvm-securekey-release-app/AttestationUtil.cpp
+++ b/cvm-securekey-release-app/AttestationUtil.cpp
@@ -228,10 +228,12 @@ std::string Util::GetMAAToken(const std::string &attestation_url, const std::str
         attest_server_url.assign(Constants::DEFAULT_ATTESTATION_URL);
     }
 
-    if (nonce.empty())
+    std::string nonce_token;
+    nonce_token.assign(nonce);
+    if (nonce_token.empty())
     {
         // use some random nonce
-        nonce.assign("ADE0101");
+        nonce_token.assign(Constants::NONCE);
     }
 
     AttestationClient *attestation_client = nullptr;

--- a/cvm-securekey-release-app/AttestationUtil.h
+++ b/cvm-securekey-release-app/AttestationUtil.h
@@ -151,8 +151,9 @@ public:
     /// Get attestation token from the attestation service.
     /// </summary>
     /// <param name="attestation_url">Attestation service URL.</param>
+    /// <param name="nonce">unique nonce per attestation request.</param>
     /// <returns>MAA token</returns>
-    static std::string GetMAAToken(const std::string &attestation_url);
+    static std::string GetMAAToken(const std::string &attestation_url, const std::string &nonce);
 
     /// <summary>
     /// Split string by delimeter.
@@ -164,26 +165,36 @@ public:
     /// <summary>
     /// Do secure key release (SKR) to get the key encryption key (KEK).
     /// </summary>
+    /// <param name="attestation_url">Attestation service URL.</param>
+    /// <param name="nonce">unique nonce per attestation request.</param>
     /// <param name="KEKUrl">AKV URL of the key</param>
     /// <param name="pkey">OpenSSL key representation</param>
     /// <returns>True if successful</returns>
-    static bool doSKR(std::string KEKUrl, EVP_PKEY **pkey);
+    static bool doSKR(const std::string &attestation_url, const std::string &nonce, std::string KEKUrl, EVP_PKEY **pkey);
 
     /// <summary>
     /// Wrap the symmetric key with the public key of the key encryption key (KEK).
     /// </summary>
+    /// <param name="attestation_url">Attestation service URL.</param>
+    /// <param name="nonce">unique nonce per attestation request.</param>
     /// <param name="plainText">Plain text symmetric key</param>
     /// <param name="key_enc_key">KEK</param>
     /// <returns>Wrapped key</returns>
-    static std::string WrapKey(const std::string &plainText,
+    static std::string WrapKey(const std::string &attestation_url,
+                               const std::string &nonce,
+                               const std::string &plainText,
                                const std::string &key_enc_key);
 
     /// <summary>
     /// Unwrap the symmetric key using the private key of the key encryption key (KEK).
     /// </summary>
+    /// <param name="attestation_url">Attestation service URL.</param>
+    /// <param name="nonce">unique nonce per attestation request.</param>
     /// <param name="cipherText">Wrapped symmetric key</param>
     /// <param name="key_enc_key">KEK</param>
     /// <returns>Plain text symmetric key</returns>
-    static std::string UnwrapKey(const std::string &cipherText,
+    static std::string UnwrapKey(const std::string &attestation_url,
+                                 const std::string &nonce,
+                                 const std::string &cipherText,
                                  const std::string &key_enc_key);
 };

--- a/cvm-securekey-release-app/AttestationUtil.h
+++ b/cvm-securekey-release-app/AttestationUtil.h
@@ -139,7 +139,8 @@ public:
 
     static std::string GetKeyVaultResponse(const std::string &requestUri,
                                            const std::string &access_token,
-                                           const std::string &attestation_token);
+                                           const std::string &attestation_token,
+                                           const std::string &nonce);
 
     /// <summary>
     /// Retrieve MSI token from IMDS servce

--- a/cvm-securekey-release-app/AttestationUtil.h
+++ b/cvm-securekey-release-app/AttestationUtil.h
@@ -144,8 +144,9 @@ public:
     /// <summary>
     /// Retrieve MSI token from IMDS servce
     /// </summary>
+    /// <param name="client_id">optional client_id of the managed identity if there are multiple associated with the node</param>
     /// <returns>MSI token for the resource</returns>
-    static std::string GetIMDSToken();
+    static std::string GetIMDSToken(std::string client_id = "");
 
     /// <summary>
     /// Get attestation token from the attestation service.
@@ -169,8 +170,12 @@ public:
     /// <param name="nonce">unique nonce per attestation request.</param>
     /// <param name="KEKUrl">AKV URL of the key</param>
     /// <param name="pkey">OpenSSL key representation</param>
+    /// <param name="client_id">Optional client_id to be used for the IMDS request if multiple identities are associated with the node</param>
     /// <returns>True if successful</returns>
-    static bool doSKR(const std::string &attestation_url, const std::string &nonce, std::string KEKUrl, EVP_PKEY **pkey);
+    static bool doSKR(const std::string &attestation_url,
+                      const std::string &nonce, std::string KEKUrl,
+                      EVP_PKEY **pkey,
+                      const std::string &client_id);
 
     /// <summary>
     /// Wrap the symmetric key with the public key of the key encryption key (KEK).
@@ -179,11 +184,13 @@ public:
     /// <param name="nonce">unique nonce per attestation request.</param>
     /// <param name="plainText">Plain text symmetric key</param>
     /// <param name="key_enc_key">KEK</param>
+    /// <param name="client_id">Optional client_id to be used for the IMDS request if multiple identities are associated with the node</param>
     /// <returns>Wrapped key</returns>
     static std::string WrapKey(const std::string &attestation_url,
                                const std::string &nonce,
                                const std::string &plainText,
-                               const std::string &key_enc_key);
+                               const std::string &key_enc_key,
+                               const std::string &client_id);
 
     /// <summary>
     /// Unwrap the symmetric key using the private key of the key encryption key (KEK).
@@ -192,9 +199,11 @@ public:
     /// <param name="nonce">unique nonce per attestation request.</param>
     /// <param name="cipherText">Wrapped symmetric key</param>
     /// <param name="key_enc_key">KEK</param>
+    /// <param name="client_id">Optional client_id to be used for the IMDS request if multiple identities are associated with the node</param>
     /// <returns>Plain text symmetric key</returns>
     static std::string UnwrapKey(const std::string &attestation_url,
                                  const std::string &nonce,
                                  const std::string &cipherText,
-                                 const std::string &key_enc_key);
+                                 const std::string &key_enc_key,
+                                 const std::string &client_id);
 };

--- a/cvm-securekey-release-app/Constants.h
+++ b/cvm-securekey-release-app/Constants.h
@@ -21,6 +21,5 @@ public:
     static inline const std::string IMDS_TOKEN_URL{"http://169.254.169.254/metadata/identity/oauth2/token"};
 
     // IMDS api version
-    static inline const std::string IMDS_API_VERSION="2018-02-01";
-
+    static inline const std::string IMDS_API_VERSION = "2018-02-01";
 };

--- a/cvm-securekey-release-app/Constants.h
+++ b/cvm-securekey-release-app/Constants.h
@@ -22,4 +22,7 @@ public:
 
     // IMDS api version
     static inline const std::string IMDS_API_VERSION = "2018-02-01";
+
+    // Default Nonce
+    static inline const std::string NONCE = "ADE0101";
 };

--- a/cvm-securekey-release-app/Main.cpp
+++ b/cvm-securekey-release-app/Main.cpp
@@ -38,18 +38,23 @@ int main(int argc, char *argv[])
     TRACE_OUT("Main started");
 
     std::string attestation_url;
+    std::string nonce;
     std::string sym_key;
     std::string key_enc_key_url;
     Operation op = Operation::None;
 
     int opt;
-    while ((opt = getopt(argc, argv, "a:k:s:uw")) != -1)
+    while ((opt = getopt(argc, argv, "a:n:k:s:uw")) != -1)
     {
         switch (opt)
         {
         case 'a':
             attestation_url.assign(optarg);
             TRACE_OUT("attestation_url: %s", attestation_url.c_str());
+            break;
+        case 'n':
+            nonce.assign(optarg);
+            TRACE_OUT("nonce: %s", nonce.c_str());
             break;
         case 'k':
             key_enc_key_url.assign(optarg);
@@ -82,11 +87,11 @@ int main(int argc, char *argv[])
         switch (op)
         {
         case Operation::WrapKey:
-            result = Util::WrapKey(sym_key, key_enc_key_url);
+            result = Util::WrapKey(attestation_url, nonce, sym_key, key_enc_key_url);
             std::cout << result << std::endl;
             break;
         case Operation::UnwrapKey:
-            result = Util::UnwrapKey(sym_key, key_enc_key_url);
+            result = Util::UnwrapKey(attestation_url, nonce, sym_key, key_enc_key_url);
             std::cout << result << std::endl;
             break;
         default:

--- a/cvm-securekey-release-app/Main.cpp
+++ b/cvm-securekey-release-app/Main.cpp
@@ -22,7 +22,7 @@
 
 void usage(char *programName)
 {
-    printf("Usage: %s -a <attestation-endpoint> -n <optional-nonce> -k KEK -s symkey|base64(wrappedSymKey) -w|-u (Wrap|Unwrap) \n", programName);
+    printf("Usage: %s -a <attestation-endpoint> -n <optional-nonce> -k KEK -c <optional-imds-client-id> -s symkey|base64(wrappedSymKey) -w|-u (Wrap|Unwrap) \n", programName);
 }
 
 enum class Operation
@@ -41,10 +41,11 @@ int main(int argc, char *argv[])
     std::string nonce;
     std::string sym_key;
     std::string key_enc_key_url;
+    std::string client_id;
     Operation op = Operation::None;
 
     int opt;
-    while ((opt = getopt(argc, argv, "a:n:k:s:uw")) != -1)
+    while ((opt = getopt(argc, argv, "a:n:k:c:s:uw")) != -1)
     {
         switch (opt)
         {
@@ -59,6 +60,10 @@ int main(int argc, char *argv[])
         case 'k':
             key_enc_key_url.assign(optarg);
             TRACE_OUT("key_enc_key_url: %s", key_enc_key_url.c_str());
+            break;
+        case 'c':
+            client_id.assign(optarg);
+            TRACE_OUT("client_id: %s", client_id.c_str());
             break;
         case 'u':
             op = Operation::UnwrapKey;
@@ -87,11 +92,11 @@ int main(int argc, char *argv[])
         switch (op)
         {
         case Operation::WrapKey:
-            result = Util::WrapKey(attestation_url, nonce, sym_key, key_enc_key_url);
+            result = Util::WrapKey(attestation_url, nonce, sym_key, key_enc_key_url, client_id);
             std::cout << result << std::endl;
             break;
         case Operation::UnwrapKey:
-            result = Util::UnwrapKey(attestation_url, nonce, sym_key, key_enc_key_url);
+            result = Util::UnwrapKey(attestation_url, nonce, sym_key, key_enc_key_url, client_id);
             std::cout << result << std::endl;
             break;
         default:

--- a/cvm-securekey-release-app/Main.cpp
+++ b/cvm-securekey-release-app/Main.cpp
@@ -22,7 +22,7 @@
 
 void usage(char *programName)
 {
-    printf("Usage: %s -a <attestation-endpoint> -k KEK -s symkey|base64(wrappedSymKey) -w|-u (Wrap|Unwrap) \n", programName);
+    printf("Usage: %s -a <attestation-endpoint> -n <optional-nonce> -k KEK -s symkey|base64(wrappedSymKey) -w|-u (Wrap|Unwrap) \n", programName);
 }
 
 enum class Operation

--- a/cvm-securekey-release-app/README.md
+++ b/cvm-securekey-release-app/README.md
@@ -84,8 +84,16 @@ sudo ./AzureAttestSKR -a "https://sharedweu.weu.attest.azure.net" -k "https://my
 
 ```
 
-If a nonce needs to be passed into the MAA token as client_payload, use `-n` argument as below
+Optional Arguments
+
+- `-n`: If a nonce needs to be passed as client_payload json, use `-n` argument as below. This demo app only supports `nonce` key, however clients can send in any arbitary json as the `client_payload` in the MAA request.
 
 ```sh
-sudo ./AzureAttestSKR -a "https://sharedweu.weu.attest.azure.net" -n <some-identifier-per-maa-request> -k "https://mykv.vault.azure.net/keys/mykey/version_GUID" -s <copy_base64_from_previous_run> -u
+sudo ./AzureAttestSKR -a "https://sharedweu.weu.attest.azure.net" -n "<some-identifier-per-maa-request>" -k "https://mykv.vault.azure.net/keys/mykey/version_GUID" -s <copy_base64_from_previous_run> -u
+```
+
+- `-c`: If multiple managed identities are associated with the Confidential VM, `client_id` can be used to get the IMDS token for a selected identity
+
+```sh
+sudo ./AzureAttestSKR -a "https://sharedweu.weu.attest.azure.net" -k "https://mykv.vault.azure.net/keys/mykey/version_GUID" -c "<some-azure-managed-identity-client_id>" -s "<copy_base64_from_previous_run>" -u
 ```

--- a/cvm-securekey-release-app/README.md
+++ b/cvm-securekey-release-app/README.md
@@ -1,4 +1,5 @@
 # AKV (or mHSM) Secure Key Release sample application
+
 The code in this directory demonstrates how to get an asymetric encryption key stored in Azure Keyvault or managed HSM released to a Linux Confidential or Trusted Launch VM. The attesting of the VM state cryptographically verifies it meets the requirements of a baseline attestation policy. The securely released asymmetric key can be used to wrap and unwrap a symmetric key.
 
 ## Build Instructions for Linux
@@ -6,11 +7,13 @@ The code in this directory demonstrates how to get an asymetric encryption key s
 Create a Linux Confidential or Trusted Launch virtual machine in Azure and clone the application.
 
 Use the below command to install the `build-essential` package. This package will install everything required for compiling our sample application written in C++.
+
 ```sh
 $ sudo apt-get install build-essential
 ```
 
 Install the below packages
+
 ```sh
 $ sudo apt-get install libcurl4-openssl-dev
 $ sudo apt-get install libjsoncpp-dev
@@ -21,11 +24,12 @@ $ sudo apt install nlohmann-json3-dev
 Download the attestation package from the following location - https://packages.microsoft.com/repos/azurecore/pool/main/a/azguestattestation1/
 
 Use the below command to install the attestation package
+
 ```sh
 $ sudo dpkg -i azguestattestation1_1.0.5_amd64.deb
 ```
 
-Once the above packages have been installed, use  below steps to build and run the app
+Once the above packages have been installed, use below steps to build and run the app
 
 ```sh
 $ cd cvm-securekey-release-app/
@@ -35,36 +39,42 @@ $ make
 ```
 
 # Execution instructions.
+
 1- Create or use an existing Azure KeyVault in your subscription.
 2- Create an RSA key with below sample confidentiality policy.
+
 ```json
 {
-	"version": "1.0.0",
-	"anyOf": [
-		{
-			"authority": "https://sharedweu.weu.attest.azure.net",
-			"allOf": [
-				{
-					"claim": "x-ms-isolation-tee.x-ms-attestation-type",
-					"equals": "sevsnpvm"
-				},
-				{
-					"claim": "x-ms-isolation-tee.x-ms-compliance-status",
-					"equals": "azure-compliant-cvm"
-				}
-			]
-		}
-	]
+  "version": "1.0.0",
+  "anyOf": [
+    {
+      "authority": "https://sharedweu.weu.attest.azure.net",
+      "allOf": [
+        {
+          "claim": "x-ms-isolation-tee.x-ms-attestation-type",
+          "equals": "sevsnpvm"
+        },
+        {
+          "claim": "x-ms-isolation-tee.x-ms-compliance-status",
+          "equals": "azure-compliant-cvm"
+        }
+      ]
+    }
+  ]
 }
 ```
+
 3- Create or use an existing Managed Identity (user-assigned).
 4- Assign the managed identity to the confidential VM.
-4- Grant 'Get' and 'Release' permissions to the managed identity in the Azure Keyvault access policies. 
+4- Grant 'Get' and 'Release' permissions to the managed identity in the Azure Keyvault access policies.
 5- Copy the built sample application to your target confidential VM.
+
 ```sh
 scp -P 22 -i ssh.key AzureAttestSKR user@<VM_ip>:~
 ```
+
 6- Execute wrap and unwrap key operations as shown below:
+
 ```sh
 # to wrap a secret key
 sudo ./AzureAttestSKR -a "https://sharedweu.weu.attest.azure.net" -k "https://mykv.vault.azure.net/keys/mykey/version_GUID" -s mysecretkey123 -w
@@ -72,4 +82,10 @@ sudo ./AzureAttestSKR -a "https://sharedweu.weu.attest.azure.net" -k "https://my
 # to unwrap an encrypted key
 sudo ./AzureAttestSKR -a "https://sharedweu.weu.attest.azure.net" -k "https://mykv.vault.azure.net/keys/mykey/version_GUID" -s <copy_base64_from_previous_run> -u
 
+```
+
+If a nonce needs to be passed into the MAA token as client_payload, use `-n` argument as below
+
+```sh
+sudo ./AzureAttestSKR -a "https://sharedweu.weu.attest.azure.net" -n <some-identifier-per-maa-request> -k "https://mykv.vault.azure.net/keys/mykey/version_GUID" -s <copy_base64_from_previous_run> -u
 ```


### PR DESCRIPTION
This PR fixes https://github.com/Azure/confidential-computing-cvm-guest-attestation/issues/25 by

- Allowing clients to pass a custom MAA URL and use it for generating an MAA token
- Allowing clients to pass nonce that are sent across to MAA in the client_payload section
- Allowing clients to pass a specific client_id for invoking IMDS call if there are multiple managed identities associated with the node