### PR TITLE
Azure Attest SKR sample: compile for OpenSSL 3.0

### DIFF
--- a/cvm-securekey-release-app/AttestationUtil.cpp
+++ b/cvm-securekey-release-app/AttestationUtil.cpp
@@ -663,7 +663,7 @@ bool Util::doSKR(const std::string &attestation_url,
         }
         else
         {
-            access_token = std::move(Util::GetIMDSToken());
+            access_token = std::move(Util::GetIMDSToken(KEKUrl));
         }
 
         TRACE_OUT("AkvMsiAccessToken: %s", access_token.c_str());
@@ -913,8 +913,7 @@ std::string Util::WrapKey(const std::string &attestation_url,
         exit(-1);
     }
 
-    RSA *rsa = EVP_PKEY_get1_RSA(pkey);
-    int rsaSize = RSA_size(rsa);
+    int rsaSize = EVP_PKEY_get_size(pkey);
     TRACE_OUT("Wrapping: %s", sym_key.c_str());
 
     size_t encrypted_length = 0;
@@ -954,8 +953,7 @@ std::string Util::UnwrapKey(const std::string &attestation_url,
         exit(-1);
     }
 
-    RSA *rsa = EVP_PKEY_get1_RSA(pkey);
-    int rsaSize = RSA_size(rsa);
+    int rsaSize = EVP_PKEY_get_size(pkey);
     TRACE_OUT("Unwrapping: %s\n", wrapped_key_base64.c_str());
     std::vector<BYTE> wrapped_key = Util::base64_to_binary(wrapped_key_base64);
 

--- a/cvm-securekey-release-app/AttestationUtil.cpp
+++ b/cvm-securekey-release-app/AttestationUtil.cpp
@@ -407,6 +407,21 @@ std::vector<std::string> Util::SplitString(const std::string &str, char delim)
     return result;
 }
 
+/// Get the modulus size in bytes of RSA key.
+int RSA_get_size(EVP_PKEY *pkey)
+{
+    int rsaModulusSize = 0;
+#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
+    // It is OSSL >= 3.0
+    rsaModulusSize = EVP_PKEY_get_size(pkey);
+#else
+    RSA *rsa = EVP_PKEY_get1_RSA(pkey);
+    rsaModulusSize = RSA_size(rsa);
+#endif
+
+    return rsaModulusSize;
+}
+
 /// handle openssl errors
 static void handle_openssl_errors(void)
 {
@@ -913,7 +928,7 @@ std::string Util::WrapKey(const std::string &attestation_url,
         exit(-1);
     }
 
-    int rsaSize = EVP_PKEY_get_size(pkey);
+    int rsaSize = RSA_get_size(pkey);
     TRACE_OUT("Wrapping: %s", sym_key.c_str());
 
     size_t encrypted_length = 0;
@@ -953,7 +968,7 @@ std::string Util::UnwrapKey(const std::string &attestation_url,
         exit(-1);
     }
 
-    int rsaSize = EVP_PKEY_get_size(pkey);
+    int rsaSize = RSA_get_size(pkey);
     TRACE_OUT("Unwrapping: %s\n", wrapped_key_base64.c_str());
     std::vector<BYTE> wrapped_key = Util::base64_to_binary(wrapped_key_base64);
 

--- a/cvm-securekey-release-app/AttestationUtil.cpp
+++ b/cvm-securekey-release-app/AttestationUtil.cpp
@@ -889,6 +889,9 @@ int rsa_decrypt(EVP_PKEY *pkey, const PBYTE msg, size_t msglen, PBYTE *dec, size
     if (EVP_PKEY_decrypt_init(ctx) <= 0)
         handleErrors();
 
+#if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
+    // TODO: investiagate why setting padding and md algorithms causing SIGSEGV in OSSL 3.x
+#else
     // Set the RSA padding mode to PKCS #1 OAEP
     if (EVP_PKEY_CTX_set_rsa_padding(ctx, RSA_PKCS1_OAEP_PADDING) <= 0)
         handleErrors();
@@ -896,6 +899,7 @@ int rsa_decrypt(EVP_PKEY *pkey, const PBYTE msg, size_t msglen, PBYTE *dec, size
     // Set RSA signature scheme to SHA256
     if (EVP_PKEY_CTX_set_rsa_oaep_md(ctx, EVP_sha256()) <= 0) // TODO: can be a parameter
         handleErrors();
+#endif
 
     // Determine the buffer length for the encrypted data
     if (EVP_PKEY_decrypt(ctx, NULL, &outlen, msg, msglen) <= 0)

--- a/cvm-securekey-release-app/AttestationUtil.h
+++ b/cvm-securekey-release-app/AttestationUtil.h
@@ -21,6 +21,7 @@ typedef unsigned long DWORD;
 #define GetLastError() errno
 #endif
 
+#include <openssl/opensslv.h>
 #include <openssl/evp.h>
 #include <openssl/err.h>
 #include <openssl/pkcs7.h>

--- a/cvm-securekey-release-app/CMakeLists.txt
+++ b/cvm-securekey-release-app/CMakeLists.txt
@@ -29,4 +29,4 @@ add_executable(${CMAKE_PROJECT_TARGET}
     Main.cpp
 )
 
-target_link_libraries(${CMAKE_PROJECT_TARGET} azguestattestation curl jsoncpp)
+target_link_libraries(${CMAKE_PROJECT_TARGET} azguestattestation curl jsoncpp crypto)


### PR DESCRIPTION
Ubuntu 22.04 ships OSSL 3.x and there are incompatible API changes with OSSL 1.1.1