### PR TITLE
Update AAD Token with the correct mHSM Resource URL

### DIFF
--- a/cvm-securekey-release-app/AttestationUtil.cpp
+++ b/cvm-securekey-release-app/AttestationUtil.cpp
@@ -186,6 +186,34 @@ static inline std::string GetImdsTokenUrl(std::string url)
     return oss.str();
 }
 
+// Define a utility method to determine the resource URL based on KEKUrl
+std::string getResourceUrl(const std::string &KEKUrl, bool isIMDS = true)
+{
+    // Constants for suffixes and corresponding resource URLs
+    const std::string AKV_URL_SUFFIX = Constants::AKV_URL_SUFFIX;
+    const std::string MHSM_URL_SUFFIX = Constants::MHSM_URL_SUFFIX;
+    const std::string AKV_RESOURCE_URL = Constants::AKV_RESOURCE_URL;
+    const std::string MHSM_RESOURCE_URL = Constants::MHSM_RESOURCE_URL;
+
+    // Check if AKV suffix is present in KEKUrl
+    if (KEKUrl.find(AKV_URL_SUFFIX) != std::string::npos)
+    {
+        TRACE_OUT("AKV resource suffix found in KEKUrl");
+        return isIMDS ? AKV_RESOURCE_URL : AKV_RESOURCE_URL + "/.default";
+    }
+    // If AKV suffix is not found, check if MHSM suffix is present
+    else if (KEKUrl.find(MHSM_URL_SUFFIX) != std::string::npos)
+    {
+        TRACE_OUT("MHSM resource suffix found in KEKUrl");
+        return isIMDS ? MHSM_RESOURCE_URL : MHSM_RESOURCE_URL + "/.default";
+    }
+    // If neither AKV nor MHSM suffix is found, throw an error
+    else
+    {
+        TRACE_ERROR_EXIT("Invalid resource suffix found in KEKUrl: " + KEKUrl)
+    }
+}
+
 /// \copydoc Util::GetIMDSToken()
 std::string Util::GetIMDSToken(const std::string &KEKUrl)
 {
@@ -198,22 +226,7 @@ std::string Util::GetIMDSToken(const std::string &KEKUrl)
     }
 
     // AKV and mHSM has different audience need to be passed to IMDS.
-    std::string resourceUrl;
-    if (KEKUrl.find(Constants::AKV_URL_SUFFIX) != std::string::npos)
-    {
-        resourceUrl = Constants::AKV_RESOURCE_URL;
-        TRACE_OUT("AKV resource suffix found in KEKUrl");
-    }
-    else if (KEKUrl.find(Constants::MHSM_URL_SUFFIX) != std::string::npos)
-    {
-        resourceUrl = Constants::MHSM_RESOURCE_URL;
-        TRACE_OUT("MHSM resource suffix found in KEKUrl");
-    }
-    else
-    {
-        TRACE_ERROR_EXIT("Invalid resource suffix found in KEKUrl")
-    }
-
+    std::string resourceUrl = getResourceUrl(KEKUrl);
     CURLcode curlRet = curl_easy_setopt(curl, CURLOPT_URL, GetImdsTokenUrl(resourceUrl).c_str());
     if (curlRet != CURLE_OK)
     {
@@ -264,7 +277,7 @@ std::string Util::GetIMDSToken(const std::string &KEKUrl)
 }
 
 /// \copydoc Util::GetAADToken()
-std::string Util::GetAADToken()
+std::string Util::GetAADToken(const std::string &KEKUrl)
 {
     TRACE_OUT("Entering Util::GetAADToken()");
 
@@ -272,8 +285,9 @@ std::string Util::GetAADToken()
     auto clientSecret = std::getenv("AKV_SKR_CLIENT_SECRET");
     auto tenantId = std::getenv("AKV_SKR_TENANT_ID");
 
+    std::string resourceUrl = getResourceUrl(KEKUrl, false);
     std::string tokenUrl = "https://login.microsoftonline.com/" + std::string(tenantId) + "/oauth2/v2.0/token";
-    std::string postData = "client_id=" + std::string(clientId) + "&client_secret=" + std::string(clientSecret) + "&grant_type=client_credentials&scope=https://vault.azure.net/.default";
+    std::string postData = "client_id=" + std::string(clientId) + "&client_secret=" + std::string(clientSecret) + "&grant_type=client_credentials&scope= " + resourceUrl;
 
     CURL *curl = curl_easy_init();
     if (curl)
@@ -675,7 +689,7 @@ std::string Util::GetKeyVaultResponse(const std::string &requestUri,
     // Cleanup curl
     curl_slist_free_all(headers);
     curl_easy_cleanup(curl);
-    TRACE_OUT("SKR response: %s",  Util::reduct_log(responseStr).c_str());
+    TRACE_OUT("SKR response: %s", Util::reduct_log(responseStr).c_str());
     TRACE_OUT("Exiting Util::GetKeyVaultResponse()");
     return responseStr;
 }
@@ -697,7 +711,7 @@ bool Util::doSKR(const std::string &attestation_url,
         std::string access_token;
         if (akv_credential_source == Util::AkvCredentialSource::EnvServicePrincipal)
         {
-            access_token = std::move(Util::GetAADToken());
+            access_token = std::move(Util::GetAADToken(KEKUrl));
         }
         else
         {
@@ -855,7 +869,7 @@ int rsa_encrypt(EVP_PKEY *pkey, const PBYTE msg, size_t msglen, PBYTE *enc, size
         handleErrors();
 
 #if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
-    // TODO: investiagate why setting padding and md algorithms causing SIGSEGV in OSSL 3.x
+        // TODO: investiagate why setting padding and md algorithms causing SIGSEGV in OSSL 3.x
 #else
     // Set the RSA padding mode to either PKCS #1 OAEP
     if (EVP_PKEY_CTX_set_rsa_padding(ctx, RSA_PKCS1_OAEP_PADDING) <= 0)
@@ -908,7 +922,7 @@ int rsa_decrypt(EVP_PKEY *pkey, const PBYTE msg, size_t msglen, PBYTE *dec, size
         handleErrors();
 
 #if defined(OPENSSL_VERSION_MAJOR) && OPENSSL_VERSION_MAJOR >= 3
-    // TODO: investiagate why setting padding and md algorithms causing SIGSEGV in OSSL 3.x
+        // TODO: investiagate why setting padding and md algorithms causing SIGSEGV in OSSL 3.x
 #else
     // Set the RSA padding mode to PKCS #1 OAEP
     if (EVP_PKEY_CTX_set_rsa_padding(ctx, RSA_PKCS1_OAEP_PADDING) <= 0)

--- a/cvm-securekey-release-app/AttestationUtil.h
+++ b/cvm-securekey-release-app/AttestationUtil.h
@@ -58,13 +58,14 @@ inline static void Check_HResult(std::string fileName, std::string funcName, int
 #define TRACE_OUT Util::trace_out
 #define OSSL_BN_TRACE_OUT Util::ossl_bn_trace_out
 
-class Util{
+class Util
+{
 private:
     static bool isTraceOn;
-    static int traceLevel; //1: enable Util::reduct_log, 2: do nothing.
+    static int traceLevel; // 1: enable Util::reduct_log, 2: do nothing.
     static size_t lengthMask;
-public:
 
+public:
     static void set_trace(bool traceOn)
     {
         isTraceOn = traceOn;
@@ -97,13 +98,15 @@ public:
         }
     }
 
-    inline static std::string reduct_log(const std::string& str)
+    inline static std::string reduct_log(const std::string &str)
     {
         std::string retStr(str);
-        if(traceLevel==1){
+        if (traceLevel == 1)
+        {
             double percentage = reduct_log_percentage(str);
-            size_t lengthMask = retStr.size()*(percentage/100);
-            if(retStr.size()>lengthMask){
+            size_t lengthMask = retStr.size() * (percentage / 100);
+            if (retStr.size() > lengthMask)
+            {
                 retStr.resize(lengthMask);
                 retStr.append("...");
             }
@@ -111,11 +114,12 @@ public:
         return retStr.c_str();
     }
 
-    inline static double reduct_log_percentage(const std::string& str)
+    inline static double reduct_log_percentage(const std::string &str)
     {
         std::string err = "error";
-        auto it = std::search(str.begin(), str.end(), err.begin(), err.end(), 
-        [](char a, char b){return std::tolower(a)==std::tolower(b);});
+        auto it = std::search(str.begin(), str.end(), err.begin(), err.end(),
+                              [](char a, char b)
+                              { return std::tolower(a) == std::tolower(b); });
         if (it != str.end())
             return 100;
         return 15;
@@ -123,7 +127,7 @@ public:
 
     inline static void ossl_bn_trace_out(const BIGNUM *bn)
     {
-        if(isTraceOn)
+        if (isTraceOn)
         {
             BN_print_fp(stderr, bn);
         }
@@ -226,8 +230,9 @@ public:
     // <summary>
     /// Retrieve MSI token from Service Principal Credentials available in the Environment Variables
     /// </summary>
+    /// <param name="KEKUrl">Key encryption key URL</param>
     /// <returns>MSI token for the resource</returns>
-    static std::string GetAADToken();
+    static std::string GetAADToken(const std::string &KEKUrl);
 
     /// <summary>
     /// Get attestation token from the attestation service.
@@ -298,7 +303,7 @@ public:
     /// <param name="akv_credential_source">AkvCredentialSource type for accessing Key Vault</param>
     /// <returns>True if key release succeeds, False otherwise</returns>
     static bool ReleaseKey(const std::string &attestation_url,
-                                  const std::string &nonce,
-                                  const std::string &key_enc_key,
-                                  const Util::AkvCredentialSource &akv_credential_source);
+                           const std::string &nonce,
+                           const std::string &key_enc_key,
+                           const Util::AkvCredentialSource &akv_credential_source);
 };


### PR DESCRIPTION
For Service Principal based authentication to an mHSM, the scope was hardcoded to AKV. 