### PR TITLE
Update cvm-guest-attestation.md

### DIFF
--- a/cvm-guest-attestation.md
+++ b/cvm-guest-attestation.md
@@ -95,7 +95,12 @@ cryptographically verified that it is running on a genuine AMD processor and tha
 enabled for confidentiality on this processor.
 
 ```
-Guest report validated successfully! 
+Reported TCB Boot Loader from certificate matches the attestation report.
+Reported TCB TEE from certificate matches the attestation report.
+Reported TCB SNP from certificate matches the attestation report.
+Reported TCB Microcode from certificate matches the attestation report.
+Chip ID from certificate matches the attestation report.
+VCEK signed the Attestation Report!
 ```
     
 It is important to note that the SNP report only certifies/measures the HCL (Microsoft firmware) and UEFI binary. You will not be able to generate arbitrary SNP reports by directly calling hardware APIs.

--- a/cvm-guest-attestation.md
+++ b/cvm-guest-attestation.md
@@ -85,7 +85,7 @@ other trusted CVM or non-CVM machine.
 
 4. Install the AMD SNP Guest utility following the instructions here: [GitHub – virtee/snpguest: A CLI tool for interacting with SEV-SNP guest environment](https://github.com/virtee/snpguest), and contact AMD for support.
 5. Use AMD SNP-Guest to parse the report (to obtain the information that SNP is enabled). Note:
-    sevguest binary is in the <repo root>/target/release folder.
+    sevguest binary is in the `<repo root>/target/release` folder.
 
 ```
 % sudo ./snpguest verify attestation <directory of vcek.pem & guest_report.bin> <directory of vcek.pem & guest_report.bin>/guest_report.bin

--- a/cvm-guest-attestation.md
+++ b/cvm-guest-attestation.md
@@ -83,12 +83,12 @@ The mechanism to fetch the report is described below.
 _Note_ : Once the VCEK cert and SNP report are available, the steps below can be done on any
 other trusted CVM or non-CVM machine.
 
-4. Install the AMD SEV-Tool utility following the instructions here: [GitHub – AMDESE/sev-tool: AMD SEV Tool](https://github.com/AMDESE/sev-tool), and contact AMD for support.
-5. Use AMD SEV-Tool to parse the report (to obtain the information that SNP is enabled). Note:
-    sevtool binary is in the <repo root>/src folder.
+4. Install the AMD SNP Guest utility following the instructions here: [GitHub – virtee/snpguest: A CLI tool for interacting with SEV-SNP guest environment](https://github.com/virtee/snpguest), and contact AMD for support.
+5. Use AMD SNP-Guest to parse the report (to obtain the information that SNP is enabled). Note:
+    sevguest binary is in the <repo root>/target/release folder.
 
 ```
-% sudo ./sevtool –-ofolder <location of vcek.pem & guest_report.bin> --validate_guest_report
+% sudo ./snpguest verify attestation <directory of vcek.pem & guest_report.bin> <directory of vcek.pem & guest_report.bin>/guest_report.bin
 ```
 If you see the below output, it means that the SNP report is valid, and that HCL has
 cryptographically verified that it is running on a genuine AMD processor and that SNP is


### PR DESCRIPTION
This PR updates the CVM guest attestation documentation in [cvm-guest-attestation.md](https://github.com/Azure/confidential-computing-cvm-guest-attestation/blob/main/cvm-guest-attestation.md#linux) by replacing the _deprecated_ [sev tool](https://github.com/AMDESE/sev-tool) with the _latest_ [snp guest tool](https://github.com/virtee/snpguest).
