### PR TITLE
Use sha256 algorithm for SKR.

### DIFF
--- a/cvm-securekey-release-app/AttestationUtil.cpp
+++ b/cvm-securekey-release-app/AttestationUtil.cpp
@@ -913,13 +913,17 @@ std::string Util::GetKeyVaultResponse(const std::string &requestUri,
     }
 
     // Build the JSON request body (shared across both implementations)
+    // RSA_AES_KEY_WRAP_256 uses RSA-OAEP with SHA-256 for the transfer key,
+    // upgrading from CKM_RSA_AES_KEY_WRAP which used SHA-1.
+    // See: https://learn.microsoft.com/en-us/rest/api/keyvault/keys/release/release
     std::ostringstream requestBody;
     requestBody << "{";
     requestBody << "\"nonce\": \"" + nonce_token + "\",";
     requestBody << "\"target\": \"" << attestation_token << "\",";
-    requestBody << "\"enc\": \"CKM_RSA_AES_KEY_WRAP\"";
+    requestBody << "\"enc\": \"RSA_AES_KEY_WRAP_256\"";
     requestBody << "}";
     std::string requestBodyStr(requestBody.str());
+    TRACE_OUT("SKR wrapping algorithm: RSA_AES_KEY_WRAP_256 (RSA-OAEP-SHA256)");
 
     TRACE_OUT("SKR request URI: %s", requestUri.c_str());
     TRACE_OUT("SKR request body length: %zu, target (attestation_token) length: %zu",
@@ -1011,6 +1015,7 @@ bool Util::doSKR(const std::string &attestation_url,
         int ModulusSize = RSASize / 8;
         uint8_t *decryptedAESBytes = nullptr;
         uint32_t decryptedBytesSize = 0;
+        TRACE_OUT("TPM decrypt: RSA-OAEP with SHA-256 (matching RSA_AES_KEY_WRAP_256)");
         result = attestation_client->Decrypt(attest::EncryptionType::NONE,
                                              cipherText.data(),
                                              ModulusSize,
@@ -1018,8 +1023,8 @@ bool Util::doSKR(const std::string &attestation_url,
                                              0,
                                              &decryptedAESBytes,
                                              &decryptedBytesSize,
-                                             attest::RsaScheme::RsaOaep,   // mHSM uses RSA-OAEP wrapping
-                                             attest::RsaHashAlg::RsaSha1   // mHSM uses SHA1 hashing
+                                             attest::RsaScheme::RsaOaep,   // RSA-OAEP wrapping
+                                             attest::RsaHashAlg::RsaSha256 // SHA-256 to match RSA_AES_KEY_WRAP_256
         );
         if (result.code_ != attest::AttestationResult::ErrorCode::SUCCESS)
         {


### PR DESCRIPTION
## Upgrade SKR wrapping algorithm from CKM_RSA_AES_KEY_WRAP (SHA-1) to RSA_AES_KEY_WRAP_256 (SHA-256)

### Summary

Upgrades the AKV/mHSM Secure Key Release wrapping algorithm from `CKM_RSA_AES_KEY_WRAP` (which uses RSA-OAEP with SHA-1) to `RSA_AES_KEY_WRAP_256` (RSA-OAEP with SHA-256), eliminating the dependency on the deprecated SHA-1 hash algorithm in the key transport layer.

### Changes

- **`enc` parameter**: Changed from `"CKM_RSA_AES_KEY_WRAP"` to `"RSA_AES_KEY_WRAP_256"` in the SKR request body sent to AKV
- **TPM RSA-OAEP hash**: Changed from `RsaSha1` to `RsaSha256` in the `attestation_client->Decrypt()` call to match the new wrapping algorithm
- **Trace logs**: Added diagnostic output for the wrapping algorithm and TPM decrypt hash selection

### Motivation

`CKM_RSA_AES_KEY_WRAP` relies on SHA-1 for the RSA-OAEP padding used to encrypt the AES transfer key. SHA-1 is deprecated and increasingly restricted by compliance frameworks. AKV supports `RSA_AES_KEY_WRAP_256` (documented in the [Key Release REST API](https://learn.microsoft.com/en-us/rest/api/keyvault/keys/release/release)) which uses SHA-256 instead.

### Testing

Validated end-to-end on both platforms against a real AKV key with batch unwrap:

| Platform | VM | Result |
|----------|-----|--------|
| Windows Server 2022 |  (SEV-SNP CVM) | 2/2 keys unwrapped |
| Ubuntu 22.04 | (SEV-SNP CVM) | 2/2 keys unwrapped |

Both produced identical plaintext output, confirming the algorithm change is backward-compatible with existing wrapped keys.