### PR TITLE
Add Azure Local support to SKR sample 

### DIFF
--- a/azurelocal/build-azure-local.sh
+++ b/azurelocal/build-azure-local.sh
@@ -61,7 +61,7 @@ if [ "$CLEAN_BUILD" = true ]; then
     rm -rf "${SCRIPT_DIR}/cvm-securekey-release-app/build"
     mkdir -p "${SCRIPT_DIR}/cvm-securekey-release-app/build"
     pushd "${SCRIPT_DIR}/cvm-securekey-release-app/build" > /dev/null
-    cmake .. -DCMAKE_BUILD_TYPE=Release
+    cmake .. -DCMAKE_BUILD_TYPE=Release -DAZURE_LOCAL=ON
     make
     popd > /dev/null
 
@@ -111,7 +111,7 @@ if [ ! -f "${SKR_APP}" ]; then
     echo "Building AzureAttestSKR..."
     mkdir -p "${SCRIPT_DIR}/cvm-securekey-release-app/build"
     pushd "${SCRIPT_DIR}/cvm-securekey-release-app/build" > /dev/null
-    cmake .. -DCMAKE_BUILD_TYPE=Release
+    cmake .. -DCMAKE_BUILD_TYPE=Release -DAZURE_LOCAL=ON
     make
     popd > /dev/null
 fi

--- a/cvm-securekey-release-app/AttestationUtil.cpp
+++ b/cvm-securekey-release-app/AttestationUtil.cpp
@@ -29,6 +29,9 @@
 #include "AttestationUtil.h"
 #include "Logger.h"
 #include "Constants.h"
+#ifdef AZURE_LOCAL
+#include <hw_evidence_api.h>
+#endif
 
 #ifdef _WIN32
 #include <winhttp.h>
@@ -961,6 +964,7 @@ bool Util::doSKR(const std::string &attestation_url,
                             "MAA attestation returned an empty token. Cannot proceed with key release.");
         }
 
+#ifndef AZURE_LOCAL
         // Get Akv access token either using IMDS or Service Principal
         std::string access_token;
         if (akv_credential_source == Util::AkvCredentialSource::EnvServicePrincipal)
@@ -976,6 +980,36 @@ bool Util::doSKR(const std::string &attestation_url,
 
         std::string requestUri = Util::GetKeyVaultSKRurl(KEKUrl);
         std::string responseStr = Util::GetKeyVaultResponse(requestUri, access_token, attest_token, nonce);
+#else
+        // On Azure Local, the Evidence SDK handles AKV authentication and key release
+        // via the IGVM agent.
+        std::string nonce_token = nonce.empty() ? Constants::NONCE : nonce;
+
+        uint8_t* wrapped_key = nullptr;
+        uint32_t wrapped_key_size = 0;
+        std::string encryption_algorithm = "CKM_RSA_AES_KEY_WRAP";
+
+        hw_evidence_result skr_result = release_akv_key(
+            reinterpret_cast<uint8_t*>(const_cast<char*>(KEKUrl.c_str())),
+            static_cast<uint32_t>(KEKUrl.size()),
+            reinterpret_cast<uint8_t*>(const_cast<char*>(attest_token.c_str())),
+            static_cast<uint32_t>(attest_token.size()),
+            reinterpret_cast<uint8_t*>(const_cast<char*>(nonce_token.c_str())),
+            static_cast<uint32_t>(nonce_token.size()),
+            reinterpret_cast<uint8_t*>(const_cast<char*>(encryption_algorithm.c_str())),
+            static_cast<uint32_t>(encryption_algorithm.size()),
+            &wrapped_key,
+            &wrapped_key_size);
+
+        if (skr_result != HW_EVIDENCE_OK)
+        {
+            TRACE_ERROR_EXIT("release_akv_key() failed on Azure Local")
+        }
+
+        std::string responseStr(reinterpret_cast<char*>(wrapped_key), wrapped_key_size);
+        hw_evidence_free(wrapped_key);
+        TRACE_OUT("Azure Local SKR response: %s", Util::reduct_log(responseStr).c_str());
+#endif
 
         // Parse the response:
         json skrJson = json::parse(responseStr.c_str());

--- a/cvm-securekey-release-app/AttestationUtil.cpp
+++ b/cvm-securekey-release-app/AttestationUtil.cpp
@@ -1010,11 +1010,16 @@ bool Util::doSKR(const std::string &attestation_url,
             static_cast<uint32_t>(encryption_algorithm.size()),
             &wrapped_key_raw,
             &wrapped_key_size);
+
+        if (wrapped_key_raw == nullptr || wrapped_key_size == 0)
+        {
+            throw skr_error(EXIT_SKR_FAIL, "release_akv_key() did not return a wrapped key");
+        }
         wrapped_key.reset(wrapped_key_raw);
 
         if (skr_result != HW_EVIDENCE_OK)
         {
-            TRACE_ERROR_EXIT("release_akv_key() failed on Azure Local")
+            throw skr_error(EXIT_SKR_FAIL, "release_akv_key() failed on Azure Local");
         }
 
         std::string responseStr(reinterpret_cast<char*>(wrapped_key.get()), wrapped_key_size);

--- a/cvm-securekey-release-app/AttestationUtil.cpp
+++ b/cvm-securekey-release-app/AttestationUtil.cpp
@@ -13,6 +13,7 @@
 
 #include <cstdlib>
 #include <ctime>
+#include <memory>
 #include <thread>
 #include <vector>
 #include <string>
@@ -985,9 +986,18 @@ bool Util::doSKR(const std::string &attestation_url,
         // via the IGVM agent.
         std::string nonce_token = nonce.empty() ? Constants::NONCE : nonce;
 
-        uint8_t* wrapped_key = nullptr;
+        // RAII wrapper: ensures hw_evidence_free is called on every exit path
+        // (success, exception, early return). hw_evidence_free is documented
+        // to no-op on null, so the initial null state is safe.
+        std::unique_ptr<uint8_t, decltype(&hw_evidence_free)> wrapped_key(
+            nullptr, &hw_evidence_free);
+
+        // release_akv_key writes the allocated buffer pointer into a uint8_t**
+        // out-parameter, so we need a short-lived raw pointer; we transfer
+        // ownership to the unique_ptr immediately after the call.
+        uint8_t* wrapped_key_raw = nullptr;
         uint32_t wrapped_key_size = 0;
-        std::string encryption_algorithm = "CKM_RSA_AES_KEY_WRAP";
+        std::string encryption_algorithm = "RSA_AES_KEY_WRAP_256";
 
         hw_evidence_result skr_result = release_akv_key(
             reinterpret_cast<uint8_t*>(const_cast<char*>(KEKUrl.c_str())),
@@ -998,16 +1008,16 @@ bool Util::doSKR(const std::string &attestation_url,
             static_cast<uint32_t>(nonce_token.size()),
             reinterpret_cast<uint8_t*>(const_cast<char*>(encryption_algorithm.c_str())),
             static_cast<uint32_t>(encryption_algorithm.size()),
-            &wrapped_key,
+            &wrapped_key_raw,
             &wrapped_key_size);
+        wrapped_key.reset(wrapped_key_raw);
 
         if (skr_result != HW_EVIDENCE_OK)
         {
             TRACE_ERROR_EXIT("release_akv_key() failed on Azure Local")
         }
 
-        std::string responseStr(reinterpret_cast<char*>(wrapped_key), wrapped_key_size);
-        hw_evidence_free(wrapped_key);
+        std::string responseStr(reinterpret_cast<char*>(wrapped_key.get()), wrapped_key_size);
         TRACE_OUT("Azure Local SKR response: %s", Util::reduct_log(responseStr).c_str());
 #endif
 

--- a/cvm-securekey-release-app/AttestationUtil.cpp
+++ b/cvm-securekey-release-app/AttestationUtil.cpp
@@ -983,7 +983,7 @@ bool Util::doSKR(const std::string &attestation_url,
         std::string responseStr = Util::GetKeyVaultResponse(requestUri, access_token, attest_token, nonce);
 #else
         // On Azure Local, the Evidence SDK handles AKV authentication and key release
-        // via the IGVM agent.
+        // via the host using the cluster identity.
         std::string nonce_token = nonce.empty() ? Constants::NONCE : nonce;
 
         // RAII wrapper: ensures hw_evidence_free is called on every exit path

--- a/cvm-securekey-release-app/CMakeLists.txt
+++ b/cvm-securekey-release-app/CMakeLists.txt
@@ -35,6 +35,13 @@ add_executable(${CMAKE_PROJECT_TARGET}
 if(UNIX)
     add_definitions(-DPLATFORM_UNIX)
 
+    if(AZURE_LOCAL)
+        add_compile_definitions(AZURE_LOCAL)
+        message(STATUS "Azure Local mode: ENABLED")
+    else()
+        message(STATUS "Azure Local mode: DISABLED")
+    endif()
+
     # -------------------------------------------------------------------
     # SKR_PORTABLE_DEPLOY (default: OFF)
     #   OFF — "classic" build: hardcoded paths, links jsoncpp, no RPATH.
@@ -115,6 +122,10 @@ if(UNIX)
             jsoncpp
             crypto
         )
+    endif()
+
+    if(AZURE_LOCAL)
+        target_link_libraries(${CMAKE_PROJECT_TARGET} edge-cc-base-attestation-sdk)
     endif()
 
 elseif(WIN32)

--- a/cvm-securekey-release-app/README.md
+++ b/cvm-securekey-release-app/README.md
@@ -26,6 +26,22 @@ Use the below command to install the attestation package
 $ wget https://packages.microsoft.com/repos/azurecore/pool/main/a/azguestattestation1/azguestattestation1_1.1.2_amd64.deb
 $ sudo dpkg -i azguestattestation1_1.1.2_amd64.deb
 ```
+
+Once the above packages have been installed, use below steps to build and run the app
+
+```sh
+$ git clone --recursive https://github.com/Azure/confidential-computing-cvm-guest-attestation
+$ cd confidential-computing-cvm-guest-attestation
+$ cd cvm-securekey-release-app/
+$ mkdir build && cd build
+$ cmake .. -DCMAKE_BUILD_TYPE=Release  # Debug for more tracing output and define TRACE constant in CMakeLists.txt
+$ make
+```
+
+## Build Instructions for Azure Local
+
+On Azure Local, the Evidence SDK (`edge-cc-base-attestation-sdk`) handles AKV authentication and key release via the IGVM agent, so IMDS/Service Principal credentials are not required.
+
 Note for Azure Local the attestation package must be built from source with Azure Local support enabled.
 Use the following script from the repo root to build and install:
 
@@ -36,14 +52,12 @@ $ sudo ./ClientLibBuildAndInstallAzureLocal.sh -p  # -p to install pre-requisite
 
 See client-library/src/Readme.md for more details.
 
-Once the above packages have been installed, use below steps to build and run the app
+Once the prerequisites have been installed, build with the `AZURE_LOCAL` CMake option enabled:
 
 ```sh
-$ git clone --recursive https://github.com/Azure/confidential-computing-cvm-guest-attestation
-$ cd confidential-computing-cvm-guest-attestation
 $ cd cvm-securekey-release-app/
 $ mkdir build && cd build
-$ cmake .. -DCMAKE_BUILD_TYPE=Release  # Debug for more tracing output and define TRACE constant in CMakeLists.txt
+$ cmake .. -DCMAKE_BUILD_TYPE=Release -DAZURE_LOCAL=ON
 $ make
 ```
 
@@ -102,7 +116,7 @@ For Azure Local, use the following SKR sample policy:
 
 3- Create or use an existing Managed Identity (user-assigned).
 
-> **⚠️ Azure Local Note:** Managed Identities are not supported on Azure Local CVMs. Use a Service Principal (`-c sp`) instead. See the `-c` option below for details.
+> **⚠️ Azure Local Note:** Managed Identities are not supported on Azure Local CVMs. SKR is handled using the Azure Local cluster identity. You must grant this identity the 'Release' permissions on the key you wish to release.
 4- Assign the managed identity to the confidential VM.
 4- Grant 'Get' and 'Release' permissions to the managed identity in the Azure Keyvault access policies.
 5- Copy the built sample application to your target confidential VM.

--- a/cvm-securekey-release-app/README.md
+++ b/cvm-securekey-release-app/README.md
@@ -40,7 +40,7 @@ $ make
 
 ## Build Instructions for Azure Local
 
-On Azure Local, the Evidence SDK (`edge-cc-base-attestation-sdk`) handles AKV authentication and key release via the IGVM agent, so IMDS/Service Principal credentials are not required.
+On Azure Local, the Evidence SDK (`edge-cc-base-attestation-sdk`) handles AKV authentication and key release via the host, using the Azure Local cluster identity, so IMDS/Service Principal credentials are not required.
 
 Note for Azure Local the attestation package must be built from source with Azure Local support enabled.
 Use the following script from the repo root to build and install:


### PR DESCRIPTION
# Azure Local support for the Secure Key Release sample app

This PR updates the Secure Key Release sample app (`cvm-securekey-release-app`) to work natively on Azure Local, using the new `release_akv_key` function that uses the cluster managed identity for authorization with Azure Key Vault.

The Evidence SDK call replaces both the call to IMDS for an access token and the key release request to AKV. The attestation and key release response parsing logic is shared with the existing implementation. 

## Build changes

- Add a CMake build flag (`AZURE_LOCAL`) for the `cvm-securekey-release-app` that conditionally compiles the SKR sample to use the Evidence SDK for Secure Key Release via the host. This matches the structure introduced in https://github.com/Azure/confidential-computing-cvm-guest-attestation/pull/85.
- Set the build flag in the top level Azure Local build script (`azurelocal/build-azure-local.sh`) so that it compiles the SKR sample for Azure Local, as well as the client library and attestation sample.

