### PR TITLE
Set ca bundle paths for SKR calls.

### DIFF
--- a/cvm-securekey-release-app/AttestationUtil.cpp
+++ b/cvm-securekey-release-app/AttestationUtil.cpp
@@ -36,6 +36,8 @@
 
 #ifdef _WIN32
 #include <winhttp.h>
+#else
+#include <sys/stat.h>
 #endif
 
 using namespace attest;
@@ -813,6 +815,45 @@ static std::string GetKeyVaultResponseCurl(const std::string &requestUri,
     {
         TRACE_ERROR_EXIT("curl_easy_setopt() failed for HTTP_VERSION")
     }
+
+#ifdef PLATFORM_UNIX
+    // Resolve the CA bundle path - curl's compiled-in default may not exist on all distros.
+    // The statically-linked curl inside libazguestattestation.so was built on Ubuntu and
+    // hardcodes /etc/ssl/certs/ca-certificates.crt, which doesn't exist on RHEL/Fedora.
+    {
+        const char *ca_path = nullptr;
+        curl_version_info_data *ver = curl_version_info(CURLVERSION_NOW);
+        if (ver && ver->cainfo)
+            ca_path = ver->cainfo;
+
+        struct stat ca_st;
+        if (!ca_path || stat(ca_path, &ca_st) != 0)
+        {
+            // Compiled-in default missing - probe known distro paths.
+            static const char *ca_candidates[] = {
+                "/etc/pki/tls/certs/ca-bundle.crt",     // RHEL / Fedora / CentOS
+                "/etc/ssl/certs/ca-certificates.crt",   // Debian / Ubuntu
+                "/etc/ssl/ca-bundle.pem",               // SUSE
+                "/etc/ssl/cert.pem",                    // Alpine / macOS
+                "curl-ca-bundle.crt",                   // symlink in CWD
+                nullptr
+            };
+            for (const char **p = ca_candidates; *p; ++p)
+            {
+                if (stat(*p, &ca_st) == 0)
+                {
+                    ca_path = *p;
+                    break;
+                }
+            }
+        }
+        if (ca_path)
+        {
+            curl_easy_setopt(curl, CURLOPT_CAINFO, ca_path);
+            TRACE_OUT("CA bundle: %s", ca_path);
+        }
+    }
+#endif
 
     struct curl_slist *headers = NULL;
     std::ostringstream bearerToken;

--- a/cvm-securekey-release-app/AttestationUtil.cpp
+++ b/cvm-securekey-release-app/AttestationUtil.cpp
@@ -11,6 +11,7 @@
 #pragma warning(disable : 4996) // suppress MSVC deprecation warning for std::getenv
 #endif
 
+#include <array>
 #include <cstdlib>
 #include <ctime>
 #include <memory>
@@ -830,19 +831,18 @@ static std::string GetKeyVaultResponseCurl(const std::string &requestUri,
         if (!ca_path || stat(ca_path, &ca_st) != 0)
         {
             // Compiled-in default missing - probe known distro paths.
-            static const char *ca_candidates[] = {
+            static constexpr std::array<const char*, 5> ca_candidates = {{
                 "/etc/pki/tls/certs/ca-bundle.crt",     // RHEL / Fedora / CentOS
                 "/etc/ssl/certs/ca-certificates.crt",   // Debian / Ubuntu
                 "/etc/ssl/ca-bundle.pem",               // SUSE
                 "/etc/ssl/cert.pem",                    // Alpine / macOS
                 "curl-ca-bundle.crt",                   // symlink in CWD
-                nullptr
-            };
-            for (const char **p = ca_candidates; *p; ++p)
+            }};
+            for (const char *candidate : ca_candidates)
             {
-                if (stat(*p, &ca_st) == 0)
+                if (stat(candidate, &ca_st) == 0)
                 {
-                    ca_path = *p;
+                    ca_path = candidate;
                     break;
                 }
             }


### PR DESCRIPTION
## Fix RHEL TLS failure on AKV Secure Key Release calls

### Problem

On RHEL/Fedora/CentOS, the SKR call to Azure Key Vault fails with:
```
SKR curl_easy_perform() failed: Problem with the SSL CA cert (path? access rights?)
(error setting certificate file: /etc/ssl/certs/ca-certificates.crt)
```

The `libazguestattestation.so` ships with libcurl **statically compiled in**. That static curl was built on Ubuntu and hardcodes `/etc/ssl/certs/ca-certificates.crt` as the default CA bundle path. This path doesn't exist on RHEL (which uses `/etc/pki/tls/certs/ca-bundle.crt`).

The attestation library's own HTTP calls (MAA, IMDS) work because it explicitly sets `CURLOPT_CAINFO` with fallback logic. Our `GetKeyVaultResponseCurl()` never set it, so the broken default was used.

### Fix

Added a `#ifdef PLATFORM_UNIX` block in `GetKeyVaultResponseCurl()` that:
1. Queries `curl_version_info()` for the compiled-in CA bundle path
2. Checks if that path actually exists on the current system (`stat()`)
3. If not, probes known distro-specific paths (RHEL, Ubuntu, SUSE, Alpine)
4. Explicitly sets `CURLOPT_CAINFO` with the first valid path found

Uses `curl_version_info()->cainfo` (available since curl 7.0) instead of `CURLINFO_CAINFO` (requires curl ≥ 7.84) for compatibility with Ubuntu 22.04's libcurl 7.81.

### Testing

| Platform | Result |
|----------|--------|
| Ubuntu 22.04 CVM  | SKR succeeds |
| RHEL 9.4 CVM  | SKR succeeds |
| Windows (MSVC) | SKR succeeds |

### Files Changed

- AttestationUtil.cpp — Added `#include <sys/stat.h>` and CA bundle probe logic (+41 lines)