### PR TITLE
Fix unwrap failures due to null chars.

### DIFF
--- a/cvm-securekey-release-app/AttestationUtil.cpp
+++ b/cvm-securekey-release-app/AttestationUtil.cpp
@@ -52,8 +52,25 @@ std::vector<BYTE> Util::base64_to_binary(const std::string &base64_data)
 {
     using namespace boost::archive::iterators;
     using It = transform_width<binary_from_base64<std::string::const_iterator>, 8, 6>;
-    return boost::algorithm::trim_right_copy_if(std::vector<BYTE>(It(std::begin(base64_data)), It(std::end(base64_data))), [](char c)
-                                                { return c == '\0'; });
+
+    // Strip '=' padding before decoding. Boost's binary_from_base64 does not
+    // understand padding and would otherwise emit spurious trailing bytes.
+    // Previously those were removed by trimming trailing nulls, but that also
+    // stripped legitimate 0x00 bytes from binary payloads (e.g. RSA ciphertext
+    // ending in 0x00), shrinking a 256-byte RSA-2048 ciphertext to 255 bytes
+    // and causing OAEP decrypt to fail.
+    std::string input = base64_data;
+    input.erase(std::remove(input.begin(), input.end(), '='), input.end());
+
+    // Each base64 character carries 6 bits, so the exact decoded length is
+    // floor(chars * 6 / 8). Resizing to this length drops only the partial-
+    // group padding bits — never real trailing data bytes.
+    size_t decoded_len = (input.size() * 6) / 8;
+
+    std::vector<BYTE> decoded(It(std::begin(input)), It(std::end(input)));
+    if (decoded.size() > decoded_len)
+        decoded.resize(decoded_len);
+    return decoded;
 }
 
 /// \copydoc Util::binary_to_base64()


### PR DESCRIPTION
## Fix unwrap failure caused by base64 decode truncating trailing null bytes

### Summary
`Util::base64_to_binary` trimmed trailing `0x00` bytes from every decoded payload. For binary crypto material this is destructive: an RSA‑2048 ciphertext that happens to end in `0x00` was shrunk from 256 → 255 bytes, causing the final RSA‑OAEP‑256 decrypt of the user's wrapped recovery key to fail with `EVP_PKEY_decrypt failed` / OAEP decoding error.

Because most ciphertexts don't end in `0x00`, the bug was latent and appeared intermittent 

### Root cause
```cpp
return boost::algorithm::trim_right_copy_if(
    std::vector<BYTE>(It(begin), It(end)),
    [](char c){ return c == '\0'; });
```
The trailing‑null trim was a convenience for text/JWT payloads but is shared by the binary decode path. Boost's `binary_from_base64` does not understand `=` padding and emits spurious trailing bytes, which the trim was masking — at the cost of also eating legitimate trailing `0x00` data bytes.

### Fix
`base64_to_binary` now:
1. Strips `=` padding before decoding.
2. Computes the exact decoded length as `floor(chars * 6 / 8)`.
3. Resizes to that length — dropping only padding‑group bits, never real data bytes.

This keeps a 256‑byte RSA‑2048 ciphertext at 256 bytes even when it ends in `0x00`. `base64url_to_binary` is fixed automatically since it delegates to `base64_to_binary`.

### Evidence
- Trace (`SKR_TRACE_ON`) before fix: `RSA key size=256 bytes, wrapped_key decoded size=255 bytes` → OAEP decoding error.
- Direct Key Vault REST unwrap of the same  blob succeeded, confirming the wrapped material was valid and the fault was local decode truncation.

### Testing
- Built via Dockerfile (Ubuntu 22.04, Docker/WSL) — compiles clean and links `AzureAttestSKR`.
- Validated on an Ubuntu 24 CVM that failing wrapped material is getting successfully unwraped..

### Files changed
- AttestationUtil.cpp — `Util::base64_to_binary`

### Risk / review notes
- Security‑sensitive key‑handling path (SKR) — requires human review before merge.
- Affected callers (all in‑repo): `base64url_to_binary`, `UnwrapKey`, `UnwrapKeyBatch`, and JWT/ciphertext decode in `doSKR`. No external callers.
