### PR TITLE
Fix returned value in Util::url_encode

### DIFF
--- a/cvm-securekey-release-app/AttestationUtil.cpp
+++ b/cvm-securekey-release-app/AttestationUtil.cpp
@@ -158,7 +158,7 @@ std::string Util::url_encode(const std::string &data)
     char *output = curl_easy_escape(curl, data.c_str(), data.length());
     if (output)
     {
-        encoded_str = data;
+        encoded_str = output;
         curl_free(output);
     }
 


### PR DESCRIPTION
This PR fixes a bug in `Util::url_encode` used by the secure key release flow.

In AttestationUtil.cpp, the result from `curl_easy_escape` was being ignored and the original unencoded input was returned. The function now correctly returns the encoded output.

Value updated from "data" to "output".